### PR TITLE
Fix a bug where pipe symbols break execution

### DIFF
--- a/rffmpeg.py
+++ b/rffmpeg.py
@@ -266,7 +266,7 @@ def setup_command(target_host):
     # Parse and re-quote any problematic arguments
     for arg in cli_ffmpeg_args:
         # Match bad shell characters: * ( ) whitespace
-        if re.search('[*()\s]', arg):
+        if re.search('[*()\s|]', arg):
             rffmpeg_command.append('"{}"'.format(arg))
         else:
             rffmpeg_command.append('{}'.format(arg))


### PR DESCRIPTION
When a pipe symbol is introduced in any ffmpeg flag bash tries to pipe
the output to the second half of the command instead of passing it to
ffmpeg. Therefore it is necessary to escape. 

In my case Jellyfin tries to add this flag: `-vf format=nv12|vaapi,hwupload,scale_vaapi=format=nv12`
This effectively splits the ffmpeg command in half and breaks the execution