### PR TITLE
Enable SSH multiplexing/persistence

### DIFF
--- a/rffmpeg.py
+++ b/rffmpeg.py
@@ -223,7 +223,7 @@ def setup_remote_command(target_host):
     persist = config["remote_persist"]
     if persist > 0:
         rffmpeg_ssh_command.extend([ "-o", "ControlMaster=auto" ])
-        rffmpeg_ssh_command.extend([ "-o", "ControlPath=/dev/shm/ssh-%r@%h:%p" ])
+        rffmpeg_ssh_command.extend([ "-o", "ControlPath=/run/shm/ssh-%r@%h:%p" ])
         rffmpeg_ssh_command.extend([ "-o", "ControlPersist={}".format(persist) ])
 
     for arg in config["remote_args"]:

--- a/rffmpeg.py
+++ b/rffmpeg.py
@@ -84,7 +84,7 @@ except Exception as e:
 
 # Handle the fallback configuration using get() to avoid failing
 config["ssh_command"] = o_config["rffmpeg"]["commands"].get("ssh", "ssh")
-config["remote_persist"] = o_config["rffmpeg"]["remote"].get("persist", 0)
+config["remote_persist"] = int(o_config["rffmpeg"]["remote"].get("persist", 0))
 config["fallback_ffmpeg_command"] = o_config["rffmpeg"]["commands"].get("fallback_ffmpeg", config["ffmpeg_command"])
 config["fallback_ffprobe_command"] = o_config["rffmpeg"]["commands"].get("fallback_ffprobe", config["ffprobe_command"])
 

--- a/rffmpeg.py
+++ b/rffmpeg.py
@@ -73,7 +73,6 @@ try:
         "logfile": o_config["rffmpeg"]["logging"]["logfile"],
         "remote_hosts": o_config["rffmpeg"]["remote"]["hosts"],
         "remote_user": o_config["rffmpeg"]["remote"]["user"],
-        "remote_persist": o_config["rffmpeg"]["remote"]["persist"],
         "remote_args": o_config["rffmpeg"]["remote"]["args"],
         "pre_commands": o_config["rffmpeg"]["commands"]["pre"],
         "ffmpeg_command": o_config["rffmpeg"]["commands"]["ffmpeg"],
@@ -85,6 +84,7 @@ except Exception as e:
 
 # Handle the fallback configuration using get() to avoid failing
 config["ssh_command"] = o_config["rffmpeg"]["commands"].get("ssh", "ssh")
+config["remote_persist"] = o_config["rffmpeg"]["remote"].get("persist", 0)
 config["fallback_ffmpeg_command"] = o_config["rffmpeg"]["commands"].get("fallback_ffmpeg", config["ffmpeg_command"])
 config["fallback_ffprobe_command"] = o_config["rffmpeg"]["commands"].get("fallback_ffprobe", config["ffprobe_command"])
 

--- a/rffmpeg.py
+++ b/rffmpeg.py
@@ -223,7 +223,7 @@ def setup_remote_command(target_host):
     persist = config["remote_persist"]
     if persist > 0:
         rffmpeg_ssh_command.extend([ "-o", "ControlMaster=auto" ])
-        rffmpeg_ssh_command.extend([ "-o", "ControlPath=/tmp/persist-%r@%h:%p" ])
+        rffmpeg_ssh_command.extend([ "-o", "ControlPath=/dev/shm/ssh-%r@%h:%p" ])
         rffmpeg_ssh_command.extend([ "-o", "ControlPersist={}".format(persist) ])
 
     for arg in config["remote_args"]:

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -34,6 +34,9 @@ rffmpeg:
         # The remote SSH user to connect as
         user: jellyfin
 
+        # How long to persist SSH sessions (0 to disable)
+        persist: 120
+
         # A YAML list of additional SSH arguments (e.g. private keys),
         # one line per space-separated argument element.
         args: 

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -35,7 +35,7 @@ rffmpeg:
         user: jellyfin
 
         # How long to persist SSH sessions (0 to disable)
-        persist: 120
+        persist: 300
 
         # A YAML list of additional SSH arguments (e.g. private keys),
         # one line per space-separated argument element.


### PR DESCRIPTION
At the moment, rffmpeg has to create a new SSH connection every time the `ssh` command is called. This PR enables SSH persistence and multiplexing with `ControlMaster` so that after the initial connection and ffmpeg execution, the SSH connection is left open for further tunnels. If rffmpeg is executed within ~~120~~300 seconds (default) of the original connection, it will use the existing connection, executing the command about 500ms faster. It's a pretty small optimization, but could help improve latency on a media server with multiple concurrent users/can speed up things like changing resolution/bitrate soon after starting playback. The first connection will still have all the overhead, but subsequent connections are much faster.

Note that this isn't properly tested with rffmpeg, but I've been using this code in [my own version](https://github.com/dannytech/ffmpeg-remote-transcoder) of an rffmpeg-inspired remote transcoding script.