### PR TITLE
Fix path to ssh key

### DIFF
--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -44,7 +44,7 @@ rffmpeg:
         # one line per space-separated argument element.
         args: 
             - "-i"
-            - "/var/lib/jellyfin/id_rsa"
+            - "/var/lib/jellyfin/.ssh/id_rsa"
 
 
     # Remote command configuration


### PR DESCRIPTION
I guess you can have any path to the ssh keys, but this will make the sample configuration file match the README, which I think would be good..