### PR TITLE
Status command fix

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -608,6 +608,7 @@ def run_control(config):
         if len(fallback_processes) > 0:
             host_mappings[0] = {
                 "hostname": "localhost (fallback)",
+                "servername": "localhost (fallback)",
                 "weight": 0,
                 "current_state": "fallback",
                 "commands": fallback_processes,


### PR DESCRIPTION
When there are processes running on localhost (fallback), can't use status command because it expects servername field which is missing for locahost (fallback)