### PR TITLE
Added Functionality to set date to log files

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -109,11 +109,10 @@ def load_config():
     # Parse the keys from the logging group
     config["log_to_file"] = config_logging.get("log_to_file", True)
     config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/rffmpeg.log")
-    config["logfiledated"] =  config_logging.get("logfiledated", False)   
-    if config["logfiledated"] is True:
-        config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/"+ (datetime.today()).strftime('%Y%m%d') +"_rffmpeg.log")
-    else:
-        config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/rffmpeg.log")
+    config["datedlogfiles"] = config_logging.get("datedlogfiles", False)
+    if config["datedlogfiles"] is True:
+        config["datedlogdir"] = config_logging.get("datedlogdir", "/var/log/jellyfin")
+        config["logfile"] = f"{config['datedlogdir']}/{datetime.today().strftime('%Y%m%d')}_rffmpeg.log"
     config["logdebug"] = config_logging.get("debug", False)
 
     # Parse the keys from the state group

--- a/rffmpeg
+++ b/rffmpeg
@@ -35,6 +35,7 @@ from re import search
 from sqlite3 import connect as sqlite_connect
 from subprocess import run, PIPE
 from time import sleep
+from datetime import datetime
 
 
 # Set up the logger

--- a/rffmpeg
+++ b/rffmpeg
@@ -108,6 +108,11 @@ def load_config():
     # Parse the keys from the logging group
     config["log_to_file"] = config_logging.get("log_to_file", True)
     config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/rffmpeg.log")
+    config["logfiledated"] =  config_logging.get("logfiledated", False)   
+    if config["logfiledated"] is True:
+        config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/"+ (datetime.today()).strftime('%Y%m%d') +"_rffmpeg.log")
+    else:
+        config["logfile"] = config_logging.get("logfile", "/var/log/jellyfin/rffmpeg.log")
     config["logdebug"] = config_logging.get("debug", False)
 
     # Parse the keys from the state group

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -15,7 +15,10 @@ rffmpeg:
         # Log messages to this file.
         # Ensure the user running rffmpeg can write to this directory.
         #logfile: "/var/log/jellyfin/rffmpeg.log"
-
+        
+        # You can add the date to the logfile if you prefer to have one file per day.
+        #logfiledated: false
+        
         # Show debugging messages
         #debug: false
 

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -16,9 +16,14 @@ rffmpeg:
         # Ensure the user running rffmpeg can write to this directory.
         #logfile: "/var/log/jellyfin/rffmpeg.log"
         
-        # You can add the date to the logfile if you prefer to have one file per day.
-        #logfiledated: false
+        # Use a Jellyfin-logging compatible dated log format, e.g. "20221223_rffmpeg.log"
+        # Supersedes the "logfile" directive above
+        #datedlogfiles: false
         
+        # Use this base directory for Jellyfin-logging compatible dated log files if you enable "datedlogfiles"
+        # Set this to your Jellyfin logging directory if it differs from the default
+        #datedlogdir: /var/log/jellyfin
+
         # Show debugging messages
         #debug: false
 


### PR DESCRIPTION
This solves the request in #42 

Added functionality through which log files can optionally be dated instead of rotated when they get full.
[logfiledated] in the config file needs to be set to True for this to work.

There is one new module added [datetime]

The time is set in this way (datetime.today()).strftime('%Y%m%d'). I would prefer to do it as a variable to keep the code cleaner and possibility to reuse it, but I did not wantto keep adding lines to your code.
