### PR TITLE
Fixed operand failing when running init

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -112,7 +112,7 @@ def load_config():
     config["datedlogfiles"] = config_logging.get("datedlogfiles", False)
     if config["datedlogfiles"] is True:
         config["datedlogdir"] = config_logging.get("datedlogdir", "/var/log/jellyfin")
-        config["logfile"] = f"{config['datedlogdir']}/{datetime.today().strftime('%Y%m%d')}_rffmpeg.log"
+        config["logfile"] = config['datedlogdir'] + "/" + datetime.today().strftime('%Y%m%d') + "_rffmpeg.log"
     config["logdebug"] = config_logging.get("debug", False)
 
     # Parse the keys from the state group

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -22,7 +22,7 @@ rffmpeg:
         
         # Use this base directory for Jellyfin-logging compatible dated log files if you enable "datedlogfiles"
         # Set this to your Jellyfin logging directory if it differs from the default
-        #datedlogdir: "/var/log/jellyfin"
+        #datedlogdir: "/var/log/jellyfin/"
 
         # Show debugging messages
         #debug: false

--- a/rffmpeg.yml.sample
+++ b/rffmpeg.yml.sample
@@ -22,7 +22,7 @@ rffmpeg:
         
         # Use this base directory for Jellyfin-logging compatible dated log files if you enable "datedlogfiles"
         # Set this to your Jellyfin logging directory if it differs from the default
-        #datedlogdir: /var/log/jellyfin
+        #datedlogdir: "/var/log/jellyfin"
 
         # Show debugging messages
         #debug: false


### PR DESCRIPTION
The suggested way for this variable using the function handle seems to be the culprit (I am unsure of why)
`config["logfile"] = f"{config['datedlogdir']}/{datetime.today().strftime('%Y%m%d')}_rffmpeg.log"`
I changed it for
`config["logfile"] = config['datedlogdir'] + "/" + datetime.today().strftime('%Y%m%d') + "_rffmpeg.log"`
We tested building the container and it works well. 