### PR TITLE
Improve argument quoting using shlex.quote

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -25,6 +25,7 @@ import logging
 import os
 import signal
 import sys
+import shlex
 import yaml
 
 from contextlib import contextmanager
@@ -471,16 +472,8 @@ def run_remote_command(
         stdout = sys.stderr
     else:
         stdout = sys.stdout
-
-    # Append all the passed arguments with requoting of any problematic characters
-    for arg in command_args:
-        # Escape $ characters
-        arg = arg.replace('$', '\\$')
-        # Match bad shell characters: * ' ( ) | [ ] or whitespace
-        if search("[*'()|\[\]\s]", arg):
-            rffmpeg_command.append(f'"{arg}"')
-        else:
-            rffmpeg_command.append(f"{arg}")
+    
+    rffmpeg_command.extend(map(shlex.quote, command_args))
 
     log.info(f"Running command on host '{target_hostname}' ({target_servername})")
     log.debug(f"Remote command: {' '.join(rffmpeg_ssh_command + rffmpeg_command)}")


### PR DESCRIPTION
Previously quoting was done manually, now `shlex.quote` is used instead. For some pathological cases that came up in my usage of `rffmpeg run`, quoting would fail. `shlex.quote` should work in the general case and is also the routine recommended by the [official python documentation](https://docs.python.org/3/library/shlex.html#shlex.quote) for this sort of application.