### PR TITLE
Translate FFmpeg arguments for hardware acceleration

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -467,8 +467,8 @@ def translate_harware_acceleration_args(rffmpeg_command):
         }
     }
 
-    remove_args = ['-init_hw_device', 'qsv=qs@va', '-hwaccel_flags', '+unsafe_output', '-level', '50']
-    add_args = ['-hwaccel_flags', '+unsafe_output', '-threads', '1']
+    remove_args = ['-init_hw_device', 'qsv=qs@va', '-level', '50']
+    add_args = ['-hwaccel_flags', '+unsafe_output']
 
     new_args = []
     

--- a/rffmpeg
+++ b/rffmpeg
@@ -468,7 +468,7 @@ def translate_harware_acceleration_args(rffmpeg_command):
     }
 
     remove_args = ['-init_hw_device', 'qsv=qs@va', '-hwaccel_flags', '+unsafe_output', '-level', '50']
-
+    add_args = ['-hwaccel_flags', '+unsafe_output', '-threads', '1']
 
     new_args = []
     
@@ -490,6 +490,10 @@ def translate_harware_acceleration_args(rffmpeg_command):
         else:
             new_args.append(arg)
         i += 1
+    
+    # Add any additional arguments
+    for arg in add_args:
+        new_args.append(arg)
 
     return new_args
 

--- a/rffmpeg
+++ b/rffmpeg
@@ -402,6 +402,98 @@ def get_target_host(config):
     return target_hid, target_hostname, target_servername
 
 
+def translate_harware_acceleration_args(rffmpeg_command):
+    """
+    Translate hardware acceleration arguments to cude.
+    """
+    # # Check for hardware acceleration flags
+    # mappings = {
+    #     "-hwaccel": {"nvidia": "cuda", 
+    #                  "intel": "vaapi"},
+    #     "-hwaccel_device": {"nvidia": "cuda", 
+    #                         "intel": "qsv"},
+    #     "-init_hw_device": {"nvidia": "cuda=cu:0",
+    #                         "intel": ["vaapi=va:,kernel_driver=i915,driver=iHD", "qsv=qs@va"]},
+    #     "-filter_hw_device": {"nvidia": "cu",
+    #                           "intel": "qs"},
+    #     "-hwaccel_output_format": {"nvidia": "cuda",
+    #                                "intel": "vaapi"},
+    #     "-hwaccel_flags": {"nvidia": "+unsafe_output",
+    #                         "intel": None},
+    #     "-preset": {"nvidia": "p1",
+    #                "intel": "veryfast"},
+    #     "-level": {"nvidia": None,
+    #                "intel": "50"},
+    #     "-codec:v:0": {"nvidia": "hevc_nvenc",
+    #                  "intel": "hevc_qsv"},
+    #     "-vf": {"nvidia": "setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_cuda=format=yuv420p",
+    #             "intel": "setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_vaapi=format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv"},
+    #                         }
+    # print(f"rffmpeg_command: {rffmpeg_command}")
+
+    # new_args = []
+    # for arg in rffmpeg_command:
+    #     if arg in mappings:
+    #         if mappings[arg]['nvidia'] not in new_args:
+    #             new_args.append(arg)
+    #             new_args.append(mappings[arg]["nvidia"])
+           
+    #         #if the value is a list add multiple values
+    #     else:
+    #         new_args.append(arg)
+    # Replacement dictionary
+    replacements = {
+        '-init_hw_device': {
+            'vaapi=va:,kernel_driver=i915,driver=iHD': 'cuda=cu:0',
+            'qsv=qs@va': ''
+        },
+        '-filter_hw_device': {
+            'qs': 'cu'
+        },
+        '-hwaccel': {
+            'vaapi': 'cuda'
+        },
+        '-hwaccel_output_format': {
+            'vaapi': 'cuda'
+        },
+        '-codec:v:0': {
+            'hevc_qsv': 'hevc_nvenc'
+        },
+        '-preset': {
+            'veryfast': 'p1'
+        },
+        '-vf': {
+            'setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_vaapi=format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv': 'setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_cuda=format=yuv420p'
+        }
+    }
+
+    remove_args = ['-init_hw_device', 'qsv=qs@va', '-hwaccel_flags', '+unsafe_output', '-level', '50']
+
+
+    new_args = []
+    
+    i = 0
+    while i < len(rffmpeg_command):
+        arg = rffmpeg_command[i]
+        # Check if the current argument is in the replacements dictionary
+        if arg in replacements and i + 1 < len(rffmpeg_command) and rffmpeg_command[i + 1] in replacements[arg]:
+            replacement = replacements[arg][rffmpeg_command[i + 1]]
+            if replacement:  # If there's a replacement, use it
+                new_args.append(arg)
+                new_args.append(replacement)
+            # Skip the next argument since it has been replaced
+            i += 1
+        elif arg in remove_args:
+            # Skip this argument and possibly the next if it is part of a pair to remove
+            if i + 1 < len(rffmpeg_command) and rffmpeg_command[i + 1] in replacements.get(arg, {}):
+                i += 1
+        else:
+            new_args.append(arg)
+        i += 1
+
+    return new_args
+
+
 def run_local_command(config, command, command_args, stderr_as_stdout = False, mapped_cmd = None):
     """
     Run command locally, either because "localhost" is the target host, or because no good target
@@ -478,8 +570,11 @@ def run_remote_command(
     
     rffmpeg_command.extend(map(shlex.quote, command_args))
 
+    log.debug(f"Before translation: {rffmpeg_command}")
+    translated_command = translate_harware_acceleration_args(rffmpeg_command)
+
     log.info(f"Running command on host '{target_hostname}' ({target_servername})")
-    log.debug(f"Remote command: {' '.join(rffmpeg_ssh_command + rffmpeg_command)}")
+    log.debug(f"Remote command: {' '.join(rffmpeg_ssh_command + translated_command)}")
 
     with dbconn(config) as cur:
         cur.execute(
@@ -492,7 +587,7 @@ def run_remote_command(
         )
 
     return run_command(
-        rffmpeg_ssh_command + rffmpeg_command, stdin, stdout, stderr
+        rffmpeg_ssh_command + translated_command, stdin, stdout, stderr
     )
 
 


### PR DESCRIPTION
This is my first attempt at translating FFmpeg hardware acceleration arguments.

In my situation I have a media server that uses Intel QSV and a transcode server using Cuda. I wanted to use hardware acceleration on both. 

This translates the remote FFmpeg command from using QSV to Cuda acceleration. Currently I only have it from QSV to Cuda.  I tested it with HEVC videos 

Here's an example command using QSV.

`ffmpeg', '-analyzeduration', '200M', '-probesize', '1G', '-init_hw_device', 'vaapi=va:,kernel_driver=i915,driver=iHD', '-init_hw_device', 'qsv=qs@va', '-filter_hw_device', 'qs', '-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi', '-noautorotate', '-i', "'file:/media/tv/Baby Reindeer (2024) [tvdbid-417223]/Season 01/Baby Reindeer (2024) - S01E02 - Episode 2 [NF WEBDL-2160p][DV HDR10][EAC3 Atmos 5.1][h265]-FLUX.mkv'", '-noautoscale', '-map_metadata', '-1', '-map_chapters', '-1', '-threads', '0', '-map', '0:0', '-map', '0:1', '-map', '-0:s', '-codec:v:0', 'hevc_qsv', '-tag:v:0', 'hvc1', '-preset', 'veryfast', '-b:v', '19972754', '-maxrate', '19972754', '-bufsize', '39945508', '-profile:v:0', 'main', '-level', '50', '-g:v:0', '75', '-keyint_min:v:0', '75', '-vf', 'setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_vaapi=format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv', '-codec:a:0', 'libfdk_aac', '-ac', '2', '-ab', '256000', '-af', 'volume=2', '-copyts', '-avoid_negative_ts', 'disabled', '-max_muxing_queue_size', '2048', '-f', 'hls', '-max_delay', '5000000', '-hls_time', '3', '-hls_segment_type', 'fmp4', '-hls_fmp4_init_filename', 'd7166e766fe60521c16c6f3f08420c11-1.mp4', '-start_number', '0', '-hls_segment_filename', '/cache/transcodes/d7166e766fe60521c16c6f3f08420c11%d.mp4', '-hls_playlist_type', 'vod', '-hls_list_size', '0', '-y', '/cache/transcodes/d7166e766fe60521c16c6f3f08420c11.m3u8'`

This gets translated to Cuda:


`ffmpeg -analyzeduration 200M -probesize 1G -init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda -noautorotate -i 'file:/media/tv/Baby Reindeer (2024) [tvdbid-417223]/Season 01/Baby Reindeer (2024) - S01E02 - Episode 2 [NF WEBDL-2160p][DV HDR10][EAC3 Atmos 5.1][h265]-FLUX.mkv' -noautoscale -map_metadata -1 -map_chapters -1 -threads 0 -map 0:0 -map 0:1 -map -0:s -codec:v:0 hevc_nvenc -tag:v:0 hvc1 -preset p1 -b:v 19972754 -maxrate 19972754 -bufsize 39945508 -profile:v:0 main -g:v:0 75 -keyint_min:v:0 75 -vf setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_cuda=format=yuv420p -codec:a:0 libfdk_aac -ac 2 -ab 256000 -af volume=2 -copyts -avoid_negative_ts disabled -max_muxing_queue_size 2048 -f hls -max_delay 5000000 -hls_time 3 -hls_segment_type fmp4 -hls_fmp4_init_filename d7166e766fe60521c16c6f3f08420c11-1.mp4 -start_number 0 -hls_segment_filename /cache/transcodes/d7166e766fe60521c16c6f3f08420c11%d.mp4 -hls_playlist_type vod -hls_list_size 0 -y /cache/transcodes/d7166e766fe60521c16c6f3f08420c11.m3u8`

Suggestions or improvements are welcome
