### PR TITLE
Fix localhost always being saved as target_hid = 0

### DIFF
--- a/rffmpeg
+++ b/rffmpeg
@@ -404,7 +404,7 @@ def get_target_host(config):
     return target_hid, target_hostname, target_servername
 
 
-def run_local_command(config, command, command_args, stderr_as_stdout = False, mapped_cmd = None):
+def run_local_command(config, target_hid, command, command_args, stderr_as_stdout = False, mapped_cmd = None):
     """
     Run command locally, either because "localhost" is the target host, or because no good target
     host was found by get_target_host().
@@ -427,28 +427,32 @@ def run_local_command(config, command, command_args, stderr_as_stdout = False, m
     log.info("Running command on host 'localhost'")
     log.debug(f"Local command: {' '.join(rffmpeg_command)}")
 
+    if target_hid is None:
+        target_hid = 0
+        log.debug(f"Could not find any host, using fallback 'localhost'")
+
     with dbconn(config) as cur:
         cur.execute(
             f"INSERT INTO processes (host_id, process_id, cmd) VALUES ({SQL_VAR_SIGN}, {SQL_VAR_SIGN}, {SQL_VAR_SIGN})",
-            (0, config["current_pid"], command + ' ' + ' '.join(command_args)),
+            (target_hid, config["current_pid"], command + ' ' + ' '.join(command_args)),
         )
         cur.execute(
             f"INSERT INTO states (host_id, process_id, state) VALUES ({SQL_VAR_SIGN}, {SQL_VAR_SIGN}, {SQL_VAR_SIGN})",
-            (0, config["current_pid"], "active"),
+            (target_hid, config["current_pid"], "active"),
         )
 
     return run_command(rffmpeg_command, stdin, stdout, stderr)
 
 
-def run_local_ffmpeg(config, ffmpeg_args):
+def run_local_ffmpeg(config, target_hid, ffmpeg_args):
     """
     Run ffmpeg locally, either because "localhost" is the target host, or because no good target
     host was found by get_target_host().
     """
     if "ffprobe" in cmd_name:
-        return run_local_command(config, cmd_name, ffmpeg_args, mapped_cmd=config["fallback_ffprobe_command"])
+        return run_local_command(config, target_hid, cmd_name, ffmpeg_args, mapped_cmd=config["fallback_ffprobe_command"])
     else:
-        return run_local_command(config, cmd_name, ffmpeg_args, stderr_as_stdout=not any(item in config["special_flags"] for item in ffmpeg_args), mapped_cmd=config["fallback_ffmpeg_command"])
+        return run_local_command(config, target_hid, cmd_name, ffmpeg_args, stderr_as_stdout=not any(item in config["special_flags"] for item in ffmpeg_args), mapped_cmd=config["fallback_ffmpeg_command"])
 
 
 def run_remote_command(
@@ -554,7 +558,7 @@ def run_ffmpeg(config, ffmpeg_args):
     target_hid, target_hostname, target_servername = get_target_host(config)
 
     if not target_hostname or target_hostname == "localhost":
-        ret = run_local_ffmpeg(config, ffmpeg_args)
+        ret = run_local_ffmpeg(config, target_hid, ffmpeg_args)
     else:
         ret = run_remote_ffmpeg(
             config, target_hid, target_hostname, target_servername, ffmpeg_args
@@ -917,7 +921,7 @@ def run_control(config):
         target_hid, target_hostname, target_servername = get_target_host(config)
 
         if not target_hostname or target_hostname == "localhost":
-            ret = run_local_command(config, command, command_args)
+            ret = run_local_command(config, target_hid, command, command_args)
         else:
             ret = run_remote_command(
                 config,


### PR DESCRIPTION
Description

I encountered an issue when using the rffmpeg wrapper in my Jellyfin setup. The transcoding priority is configured to use the localhost first and a remote machine if the localhost is busy.

I added two machines via
 `rffmpeg add -w 1 localhost`  
 `rffmpeg add -w 1 192.168.178.XX`
`rffmpeg status`

`Hostname        Servername  ID  Weight  State  Active Commands`
`localhost       localhost   1   1       idle   N/A`
`192.168.178.XX  remote      2   1       idle   N/A`

Now start streaming on Jellyfin and invoke `rffmpeg status`:
`Hostname              Servername            ID  Weight  State     Active Commands`
`localhost (fallback)  localhost (fallback)  0   0       fallback  PID 49790: /usr/local/bin/ffmpeg`
`localhost             localhost             1   1       idle      N/A`
`192.168.178.XX        remote                2   1       idle      N/A`

Issue

While the stream gets transcoded on the local machine, the entry for 'localhost (added via `rffmpeg add` with id=1)' never transitions to 'State=active'. This causes all successive transcoding tasks to incorrectly map to 'localhost' again, despite the active transcoding process.

I implemented a fix that I tested in a few different scenarios which seems to resolve the issue.

Thanks for your great work on this project. It’s highly appreciated!
