### PR TITLE
Feat/ssh hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 1. Profit!
 
-`rffmpeg` does require a little bit more configuration to work properly however. For a comprehensive installation tutorial based on a reference setup, please see [the SETUP guide](SETUP.md).
+`rffmpeg` does require a little bit more configuration to work properly however. For a comprehensive installation tutorial based on a reference setup, please see [the SETUP guide](docs/SETUP.md).
 
 **NOTE** Jellyfin 10.10.x and newer require an additional `TMPDIR` environment variable set to somewhere exported to the remote machine, or these paths will not work properly. Edit your Jellyfin startup/service configuration to set that. See the setup guide for more details.
 
@@ -193,5 +193,7 @@ Absolutely - I'm happy to take pull requests for just about any bugfix or improv
 I'm always happy to help, though please ensure you try to follow the setup guide first - that's why I wrote it! Support can be found [on Matrix](https://matrix.to/#/#rffmpeg:matrix.org) or via email at `joshua@boniface.me`. Please note though that I may be unresponsive sometimes, though I will get back to you eventually I promise! Please don't open Issues here about setup problems; the Issue tracker is for bugs or feature requests instead.
 
 ### `rffmpeg-go` - forked project
+
+NOTICE: project was archived in Oct 27, 2024.
 
 There's also a [fork of this script written in Go](https://github.com/aleksasiriski/rffmpeg-go) with semver tags and binaries available, as well as docker images for both the [script](https://github.com/aleksasiriski/rffmpeg-go/pkgs/container/rffmpeg-go) and [Jellyfin](https://github.com/aleksasiriski/jellyfin-rffmpeg).

--- a/docs/HARDENING
+++ b/docs/HARDENING
@@ -19,14 +19,14 @@ These were tested and validated on Ubuntu 24.04 LTS, 2025-11-03
 SSH server configuration is formed out of two files
 
 1. `10-jellyfin-limits.conf` - SSH config
-2. `limited-wrapper.sh` - a script to limit what commands can be run
+2. `limited-wrapper.sh` or `limited-wrapper.py` - a script to limit what commands can be run
 
 ### 10-jellyfin-limits.conf
 
 This config file does few things
 - allows only jellyfin user to SSH from jellyfin server
 - limits jellyfin user login options to be only from jellyfin server
-- limits the commands jellyfin user can run to `limited-wrapper.sh`
+- limits the commands jellyfin user can run to `limited-wrapper.py`
 
 1. Copy `10-jellyfin-limits.conf` to `/etc/ssh/sshd_config.d`
 2. Update the IP of the jellyfin server to the file
@@ -35,16 +35,16 @@ This config file does few things
     sudo systemctl restart ssh
     ```
 
-### limited-wrapper.sh
+### limited-wrapper.sh and limited-wrapper.py
 
 This file analyses what commands are being run over SSH and limits them
 to the ones we defined.
 
 1. Update the ALLOWED list to match your `ffmpeg` file locations in the script
-2. Copy the script to `/usr/local/bin/limited-wrapper.sh` and allow only root to modify it
+2. Copy the script to `/usr/local/bin/limited-wrapper.py` and allow only root to modify it
     ```bash
-    sudo chwon root:root /usr/local/bin/limited-wrapper.sh &&\
-    sudo chmod 755 /usr/local/bin/limited-wrapper.sh
+    sudo chwon root:root /usr/local/bin/limited-wrapper.py &&\
+    sudo chmod 755 /usr/local/bin/limited-wrapper.py
     ```
 ### Test configuration
 

--- a/docs/HARDENING
+++ b/docs/HARDENING
@@ -1,0 +1,92 @@
+
+*NOTICE* Do not do these tasks until you have a verified working solution
+
+These were tested and validated on Ubuntu 24.04 LTS, 2025-11-03
+
+# Hardening
+
+- Access for jellyfin user will be limited to jellyfin1 server only
+- Commands that jellyfin user can run will be limited to ffmpeg only
+- Commands run by jellyfin user will be logged
+    - (optional) Logs stored in separate log file
+
+## Prerequisites
+
+- static IP on the jellyfin1 server
+
+## Configure SSH server
+
+SSH server configuration is formed out of two files
+
+1. `10-jellyfin-limits.conf` - SSH config
+2. `limited-wrapper.sh` - a script to limit what commands can be run
+
+### 10-jellyfin-limits.conf
+
+This config file does few things
+- allows only jellyfin user to SSH from jellyfin server
+- limits jellyfin user login options to be only from jellyfin server
+- limits the commands jellyfin user can run to `limited-wrapper.sh`
+
+1. Copy `10-jellyfin-limits.conf` to `/etc/ssh/sshd_config.d`
+2. Update the IP of the jellyfin server to the file
+3. Restart ssh
+    ```bash
+    sudo systemctl restart ssh
+    ```
+
+### limited-wrapper.sh
+
+This file analyses what commands are being run over SSH and limits them
+to the ones we defined.
+
+1. Update the ALLOWED list to match your `ffmpeg` file locations in the script
+2. Copy the script to `/usr/local/bin/limited-wrapper.sh` and allow only root to modify it
+    ```bash
+    sudo chwon root:root /usr/local/bin/limited-wrapper.sh &&\
+    sudo chmod 755 /usr/local/bin/limited-wrapper.sh
+    ```
+### Test configuration
+
+1. Login to your jellyfin1 server and run
+    ```bash
+    sudo -u jellyfin ssh jellyfin@transcode1 /usr/bin/ffmpeg
+    ```
+   command should succeed and print out ffmpeg info
+
+2. Run a command that should fail
+
+    ```bash
+    sudo -u jellyfin ssh jellyfin@transcode1 uname -a
+    ```
+    command should fail and you should see `ERROR: command not allowed.`
+
+
+### Troubleshooting
+
+#### Permission denied (publickey)
+
+1. check your auth.log
+you should see the IP you are connecting from, make sure it is the same as in your `10-jellyfin-limits.conf` -file.
+
+## Logging
+
+All commands run by the jellyfin user are logged to standard syslog (via logger). They can be extracted to their own file.
+
+### rsyslog config
+
+File `limited-wrapper-log.conf` creates a rsyslog config to redirect the log entries to a separate file
+
+1. Update the `limited-wrapper-log.conf` file with the log file name you want. Default is `/var/log/jellyfin_commands.log`
+2. Copy the file to /etc/rsyslog.d/
+3. Correct the file rights
+    ```bash
+    sudo chown root:root /etc/rsyslog.d/limited-wrapper-log.conf &&\
+    sudo chmod 644 /etc/rsyslog.d/limited-wrapper-log.conf
+    ```
+4. Create the log file
+    ```bash
+    sudo touch /var/log/jellyfin_commands.log &&\
+    sudo chown syslog:adm /var/log/jellyfin_commands.log &&\
+    sudo chmod 664 /var/log/jellyfin_commands.log
+    ```

--- a/hardening/10-jellyfin-limits.conf
+++ b/hardening/10-jellyfin-limits.conf
@@ -6,7 +6,7 @@ Match Address IPJELLYFIN
 
 Match User jellyfin, Address IPJELLYFIN
     AllowUsers jellyfin@IPJELLYFIN
-    ForceCommand /usr/local/bin/limited-wrapper.sh
+    ForceCommand /usr/local/bin/limited-wrapper.py
     PermitTTY no
     X11Forwarding no
     AllowAgentForwarding no

--- a/hardening/10-jellyfin-limits.conf
+++ b/hardening/10-jellyfin-limits.conf
@@ -1,0 +1,13 @@
+# Limit jellyfin access
+# IPJELLYFIN is our Jellyfin server
+
+Match Address IPJELLYFIN
+    AllowUsers jellyfin@IPJELLYFIN
+
+Match User jellyfin, Address IPJELLYFIN
+    AllowUsers jellyfin@IPJELLYFIN
+    ForceCommand /usr/local/bin/limited-wrapper.sh
+    PermitTTY no
+    X11Forwarding no
+    AllowAgentForwarding no
+    AllowTcpForwarding no

--- a/hardening/limited-wrapper-log.conf
+++ b/hardening/limited-wrapper-log.conf
@@ -1,3 +1,3 @@
 # Match the tag *including* the trailing colon
-:syslogtag, startswith, "limited-wrapper.sh" /var/log/jellyfin_commands.log
+:syslogtag, startswith, "limited-wrapper" /var/log/jellyfin_commands.log
 & stop

--- a/hardening/limited-wrapper-log.conf
+++ b/hardening/limited-wrapper-log.conf
@@ -1,0 +1,3 @@
+# Match the tag *including* the trailing colon
+:syslogtag, startswith, "limited-wrapper.sh" /var/log/jellyfin_commands.log
+& stop

--- a/hardening/limited-wrapper.py
+++ b/hardening/limited-wrapper.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""limited-wrapper.py
+
+Author: GPT-OSS:120b
+Version: 1.1.0
+Date: 2025-11-03
+
+Python 3 implementation of the limited-wrapper.sh script.
+It restricts SSH command execution to a whitelist of allowed binaries
+and logs activity either to the console (interactive) or to syslog.
+
+History
+   1.0.0 - 2025-11-03, initial version
+
+"""
+
+import os
+import sys
+import shlex
+import logging
+import logging.handlers
+from typing import List
+
+# ---------------------------------------------------------------------------
+# Logging utilities
+# ---------------------------------------------------------------------------
+
+def _setup_logger() -> logging.Logger:
+    logger = logging.getLogger("limited-wrapper.py")
+    logger.setLevel(logging.DEBUG)  # Capture all levels; handlers will filter
+    # Ensure no duplicate handlers if the module is reloaded
+    logger.handlers.clear()
+
+    if sys.stdout.isatty():
+        # Interactive TTY – simple console output without timestamp or level prefix
+        console = logging.StreamHandler(sys.stdout)
+        console.setLevel(logging.INFO)
+        console.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(console)
+    else:
+        # Non‑interactive – forward to syslog. Let syslog generate its own timestamp,
+        # hostname, and program identifier (the logger name). No extra formatter is
+        # needed to avoid adding the PID or duplicate timestamps.
+        try:
+            syslog = logging.handlers.SysLogHandler(address="/dev/log")
+        except OSError:
+            # Fallback for systems without /dev/log (e.g., macOS)
+            syslog = logging.handlers.SysLogHandler(address=("localhost", 514))
+        syslog.setLevel(logging.DEBUG)
+        # Prefix with logger name (script tag) to match original format
+        syslog.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+        logger.addHandler(syslog)
+    return logger
+
+_logger = _setup_logger()
+
+
+def log_msg(level: str, *msg: str) -> None:
+    """Log a message with an explicit level prefix.
+
+    The original Bash implementation prefixed the log line with the level
+    (e.g. ``DEBUG`` or ``INFO``) before sending it to syslog. To preserve that
+    format we construct ``full_msg = f"{level.upper()} {text}"`` and log the
+    resulting string. This ensures syslog entries look like:
+    ``limited-wrapper.sh: DEBUG <message>`` while interactive console output
+    remains readable.
+    """
+    text = " ".join(msg)
+    level = level.upper()
+    full_msg = f"{level} {text}"
+    if level == "DEBUG":
+        _logger.debug(full_msg)
+    elif level == "INFO":
+        _logger.info(full_msg)
+    elif level in ("WARN", "WARNING"):
+        _logger.warning(full_msg)
+    elif level == "ERROR":
+        _logger.error(full_msg)
+    else:
+        _logger.info(full_msg)
+
+
+def log_debug(*msg: str) -> None:
+    log_msg("DEBUG", *msg)
+
+
+def log_info(*msg: str) -> None:
+    log_msg("INFO", *msg)
+
+
+def log_warn(*msg: str) -> None:
+    log_msg("WARN", *msg)
+
+
+def log_error(*msg: str) -> None:
+    log_msg("ERROR", *msg)
+
+# ---------------------------------------------------------------------------
+# Whitelist of absolute paths to allowed binaries
+# ---------------------------------------------------------------------------
+ALLOWED: List[str] = [
+    "/usr/bin/ffmpeg",
+    "/usr/bin/ffprobe",
+    "/usr/local/bin/ffmpeg",
+    "/usr/local/bin/ffprobe",
+    "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+    "/usr/lib/jellyfin-ffmpeg/ffprobe",
+]
+
+
+def main() -> None:
+    req_cmd = os.getenv("SSH_ORIGINAL_COMMAND", "")
+    if not req_cmd:
+        # No command supplied – show the whitelist and exit successfully
+        print("You may run only: " + " ".join(ALLOWED))
+        sys.exit(0)
+
+    # Parse the command string respecting shell quoting (handles spaces in arguments)
+    # Using shlex.split provides proper handling of quoted arguments, unlike the
+    # original bash script which split on whitespace only.
+    try:
+        args = shlex.split(req_cmd, posix=True)
+    except ValueError as e:
+        log_error(f"Failed to parse SSH_ORIGINAL_COMMAND: {e}")
+        print("ERROR: could not parse command.")
+        sys.exit(1)
+
+    if not args:
+        log_error("Empty command after parsing.")
+        print("ERROR: empty command.")
+        sys.exit(1)
+
+    bin_path = os.path.realpath(args[0])
+    log_debug(f"Checking for bin {bin_path}")
+
+    if bin_path in ALLOWED:
+        log_info(f"Running command {req_cmd}")
+        # Ensure the argument list uses the resolved binary path as argv[0]
+        args[0] = bin_path
+        # Replace the current process with the requested command without PATH lookup
+        os.execv(bin_path, args)
+        # execv only returns on failure
+        log_error(f"Failed to exec {req_cmd}")
+        sys.exit(1)
+    else:
+        log_error(f"Not allowed {req_cmd}")
+        print("ERROR: command not allowed.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hardening/limited-wrapper.sh
+++ b/hardening/limited-wrapper.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail   # safer defaults
+
+# Author: Juha Leivo
+# Version: 1.1.0
+# Date: 2025-11-03
+#
+# Prevent unauthorized SSH command execution by allowing only a limited set of binaries.
+#
+# History
+#   1.0.0 - 2025-11-02, initial version
+#   1.1.0 - 2025-11-03, moved to use logging 1.0.0
+
+# Function to log messages both to TTY and to a logfile in syslog format
+# Ref logging.sh version 1.0.0
+log_msg() {
+    local level="$1"
+    shift
+    # Concatenate all arguments into a single string
+    local msg="$*"
+
+    # Map level to syslog priority
+    local prio="notice"
+    case "$level" in
+        INFO)   prio="info" ;;
+        WARN)   prio="warning" ;;
+        ERROR)  prio="err" ;;
+        DEBUG)  prio="debug" ;;
+        *)      prio="notice"
+                msg="$level $msg" ;;
+    esac
+
+    if [ -t 1 ]; then
+        # Interactive TTY: print plain message without level prefix
+        echo "$msg"
+    else
+        # Non‑interactive: send to syslog
+    logger -p user.$prio -t "$(basename "$0")" "$level $msg"
+    fi
+}
+
+log_debug() { log_msg DEBUG "$@"; }
+log_info()  { log_msg INFO  "$@"; }
+log_warn()  { log_msg WARN  "$@"; }
+log_error() { log_msg ERROR "$@"; }
+# ------------------------------------------------------------------
+# Whitelist of absolute paths to allowed binaries
+ALLOWED=(
+    /usr/bin/ffmpeg
+    /usr/bin/ffprobe
+    /usr/local/bin/ffmpeg
+    /usr/local/bin/ffprobe
+    /usr/lib/jellyfin-ffmpeg/ffmpeg
+    /usr/lib/jellyfin-ffmpeg/ffprobe
+)
+
+# ------------------------------------------------------------------
+REQ_CMD="${SSH_ORIGINAL_COMMAND:-}"
+if [[ -z "$REQ_CMD" ]]; then
+    echo "You may run only: ${ALLOWED[*]}"
+    exit 0
+fi
+
+# Split the command into an array preserving quoting
+read -r -a ARGS <<<"$REQ_CMD"
+BIN="${ARGS[0]}"
+
+# Resolve symlinks if possible
+if command -v realpath >/dev/null; then
+    BIN=$(realpath -m "$BIN")
+else
+    BIN=$(readlink -f "$BIN" 2>/dev/null || echo "$BIN")
+fi
+
+log_debug "Checking for bin $BIN"
+
+# Whitelist check
+for ok in "${ALLOWED[@]}"; do
+    if [[ "$BIN" == "$ok" ]]; then
+    log_info "Running command $REQ_CMD"
+        eval "exec $REQ_CMD"
+    fi
+done
+
+log_error "Not allowed $REQ_CMD"
+echo "ERROR: command not allowed." # For SSH to show the error on client
+exit 1


### PR DESCRIPTION
SSH hardening configuration

- Access for jellyfin user will be limited to jellyfin1 server only
- Commands that jellyfin user can run will be limited to ffmpeg only
- Commands run by jellyfin user will be logged
    - (optional) Logs stored in separate log file

tweaks on documentation
- docs folder
- updated SETUP.MD to be copy paste friendly
- added HARDENING.md